### PR TITLE
Change notebook backend status to not fully functional

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -15,11 +15,12 @@ Backend requirements
 
 VisPy requires at least one toolkit for opening a window and creates an OpenGL
 context. This can be done using one Qt, GLFW,SDL2, Wx, or Pyglet. You can also
-use an IPython notebook (version 3+) with WebGL for some visualizations.
+use a Jupyter notebook (version 3+) with WebGL for some visualizations although
+it is not fully functional at this time.
 
 .. warning::
 
-   You only need to have one of these packages, no need to install them all !
+   You only need to have one of these packages, no need to install them all!
 
 
 Hardware requirements


### PR DESCRIPTION
As part of https://github.com/vispy/vispy/pull/1338 this PR mentions that the notebook backend is not fully functional. I considered renaming the backends to `jupyter_*` but seeing as notebooks still have a `.ipynb` file extension I think it is fine keeping it the way it is.

TODO: Decide if there should be a "known issues" or similar section describing what isn't functional about the backend.