### PR TITLE
Fix no 2018 section on news page

### DIFF
--- a/news.rst
+++ b/news.rst
@@ -2,10 +2,14 @@
 News
 ====
 
-2017
+2018
 ----
 
 :2018/03/28: **Release!** Version 0.5.3 (:doc:`releasenotes`)
+
+2017
+----
+
 :2017/12/11: **Release!** Version 0.5.2
 :2017/11/04: **Release!** Version 0.5.1
 :2017/10/24: **Release!** Version 0.5.0

--- a/news.rst
+++ b/news.rst
@@ -5,7 +5,8 @@ News
 2017
 ----
 
-:2017/12/11: **Release!** Version 0.5.2 (:doc:`releasenotes`)
+:2018/03/28: **Release!** Version 0.5.3 (:doc:`releasenotes`)
+:2017/12/11: **Release!** Version 0.5.2
 :2017/11/04: **Release!** Version 0.5.1
 :2017/10/24: **Release!** Version 0.5.0
 


### PR DESCRIPTION
As pointed out on gitter by @rwarren there is no 2018 section on the news page. Even worse, something from 2018 was in the 2017 section.