### PR TITLE
avoid locating source on updating-prop

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -399,6 +399,9 @@ def linkcode_resolve(domain, info):
 
     try:
         source, lineno = inspect.getsourcelines(obj)
+    except TypeError:
+        # getting thrown on updating-property decorator
+        return None
     except OSError:
         source = ""
         lineno = None


### PR DESCRIPTION
this will fix https://github.com/vispy/vispy/issues/1862
(sorry about that!)

I have to admit, I'm a bit confused by this one.  The issue happens in `conf.linkcode_resolve` at the call to `inspect.getsourcelines(obj)`.  What I'm confused by is why these methods are even getting to that point ... since `linkcode_resolve` doesn't ever seem to get called on other `@property` methods... (though they too would throw this same error if they did).

That seems like a sphinx issue honestly... but I didn't trace it deep enough into sphinx to figure out why.  The approach in this PR just catches the `TypeError` on line 402 in `conf.py` and returns `None` (which is the same result that would have been achieved if `linkcode_resolve` simply hadn't been called in the first place...).