### PR TITLE
Add headless rendering to the FAQ

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -86,11 +86,10 @@ Using the OSMesa (Off-Screen Mesa) backend: ::
     import vispy
     vispy.use("osmesa")
 
-You might need to also make the `VISPY_GL_LIB` environment variable point to
-the OSMesa shared library, e.g. ::
+VisPy tries to detect the OSMesa shared library, but, if needed, it can be set
+explicitly with ::
 
     export OSMESA_LIBRARY=/usr/lib/libOSMesa.so
-    export VISPY_GL_LIB=$OSMESA_LIBRARY
 
 https://mesa-docs.readthedocs.io/en/latest/osmesa.html
 
@@ -102,14 +101,13 @@ Using the EGL backend: ::
     import vispy
     vispy.use("egl")
 
-If needed, indicate VisPy where to find the appropriate EGL shared library,
-e.g. ::
+VisPy tries to detect the EGL shared library, but, if needed, it can be set
+explicitly with ::
 
-    # Choose one.
+    # Choose one, or adapt to your system.
     export EGL_LIBRARY=/usr/lib/libEGL.so
     export EGL_LIBRARY=/usr/lib/libEGL_mesa.so
     export EGL_LIBRARY=/usr/lib/libEGL_nvidia.so
-    export VISPY_GL_LIB=$EGL_LIBRARY
 
 https://en.wikipedia.org/wiki/EGL_(API)
 

--- a/faq.rst
+++ b/faq.rst
@@ -52,24 +52,67 @@ one to do the redraw. Since many Visual objects automatically call
 do in the most performant way. Updates or requests for changes to better support
 thread-safe data updates are welcome.
 
-How to do headless rendering with VisPy?
-----------------------------------------
+How to render headless/off-screen with VisPy?
+---------------------------------------------
 
-With Xvfb: `xvfb-run -a python my_script.py`
+There are two strategies to render without windows with VisPy:
 
-Using the osmesa or egl backend:
-```python
-import vispy
-vispy.use("osmesa")
-# or
-vispy.use("egl")
-```
+1. Use Xvfb that simulates an X server in memory without displaying windows.
+   This can be used with any VisPy backend.
+2. Use a backend that directly renders into memory buffers, e.g. OSMesa or EGL.
+
+Then, in your VisPy script, use ::
+
+    image = canvas.render()
+    import imageio
+    imageio.imwrite("rendered.png", image)
+
+to save the rendered scene to an image file.
+
+Xvfb
+^^^^
+
+Wrap the command to launch your script with ``xfvb-run``: ::
+
+    xvfb-run -a python my_script.py
+
+https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml
+
+OSMesa
+^^^^^^
+
+Using the OSMesa (Off-Screen Mesa) backend: ::
+
+    import vispy
+    vispy.use("osmesa")
+
 You might need to also make the `VISPY_GL_LIB` environment variable point to
-the osmesa/egl shared library, e.g.
-```
-export OSMESA_LIBRARY=~/micromamba/envs/vispy-tests/lib/libOSMesa32.so
-export VISPY_GL_LIB=$OSMESA_LIBRARY
-```
+the OSMesa shared library, e.g. ::
+
+    export OSMESA_LIBRARY=/usr/lib/libOSMesa.so
+    export VISPY_GL_LIB=$OSMESA_LIBRARY
+
+https://mesa-docs.readthedocs.io/en/latest/osmesa.html
+
+EGL
+^^^
+
+Using the EGL backend: ::
+
+    import vispy
+    vispy.use("egl")
+
+If needed, indicate VisPy where to find the appropriate EGL shared library,
+e.g. ::
+
+    # Choose one.
+    export EGL_LIBRARY=/usr/lib/libEGL.so
+    export EGL_LIBRARY=/usr/lib/libEGL_mesa.so
+    export EGL_LIBRARY=/usr/lib/libEGL_nvidia.so
+    export VISPY_GL_LIB=$EGL_LIBRARY
+
+https://en.wikipedia.org/wiki/EGL_(API)
+
 
 How do I cite VisPy?
 --------------------

--- a/faq.rst
+++ b/faq.rst
@@ -59,7 +59,8 @@ There are two strategies to render without windows with VisPy:
 
 1. Use Xvfb that simulates an X server in memory without displaying windows.
    This can be used with any VisPy backend.
-2. Use a backend that directly renders into memory buffers, e.g. OSMesa or EGL.
+2. Use a backend that directly renders into memory buffers, e.g. OSMesa or EGL
+   (`further info <https://stackoverflow.com/a/55758789>`_).
 
 Then, in your VisPy script, use ::
 

--- a/faq.rst
+++ b/faq.rst
@@ -52,6 +52,25 @@ one to do the redraw. Since many Visual objects automatically call
 do in the most performant way. Updates or requests for changes to better support
 thread-safe data updates are welcome.
 
+How to do headless rendering with VisPy?
+----------------------------------------
+
+With Xvfb: `xvfb-run -a python my_script.py`
+
+Using the osmesa or egl backend:
+```python
+import vispy
+vispy.use("osmesa")
+# or
+vispy.use("egl")
+```
+You might need to also make the `VISPY_GL_LIB` environment variable point to
+the osmesa/egl shared library, e.g.
+```
+export OSMESA_LIBRARY=~/micromamba/envs/vispy-tests/lib/libOSMesa32.so
+export VISPY_GL_LIB=$OSMESA_LIBRARY
+```
+
 How do I cite VisPy?
 --------------------
 


### PR DESCRIPTION
Document how to use vispy for headless rendering.

- [x] Identify the alternatives: Xvfb, osmesa, egl... (are they all linked?).
- [x] Document the requirements for each alternative. (EDIT: Minimal description.)

For another issue:
- [ ] Document the possibilities from inside a docker(/nvidia) container.

Related: vispy/vispy#1464, vispy/vispy#1602, vispy/vispy#1637, vispy/vispy#1684, vispy/vispy#1734, vispy/vispy#1718, vispy/vispy#1818, vispy/vispy#1848, vispy/vispy#1872
EGL:
https://docs.mesa3d.org/egl.html
https://stackoverflow.com/a/34444984